### PR TITLE
ci: add macos-intel to supported targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest, macos-26]
+        runner: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest, macos-26, macos-26-intel]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,7 @@ skip = "*-win32 *-manylinux_i686 *-musllinux_i686"
 [tool.cibuildwheel.windows]
 # https://cibuildwheel.pypa.io/en/stable/faq/#building-with-meson-python-on-windows
 config-settings = { "setup-args" = "--vsenv" }
+
+[tool.cibuildwheel.macos.environment]  
+# VapourSynth's minimum macOS target is 13.0.  
+MACOSX_DEPLOYMENT_TARGET = "13.0"  


### PR DESCRIPTION
Also specify the `MACOSX_DEPLOYMENT_TARGET` to 13.0 since that's the minium supported target by VapourSynth